### PR TITLE
Various bug-fixes and improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+**.pyc
+bin/adlibs_flip_pops
+bin/adlibs_score
+bin/calc_fhat
+bin/pi_pops

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-CC=gcc -std=c99
+CC=gcc -std=c99 -W -Wall -Wextra
 
-all: bin/adlibs_flip_pops bin/adlibs_score bin/calc_fhat bin/pi_pops
+EXECUTABLES=bin/adlibs_flip_pops bin/adlibs_score bin/calc_fhat bin/pi_pops
+
+all: $(EXECUTABLES)
 
 bin/adlibs_flip_pops: src/adlibs_flip_pops.c
 	$(CC) src/adlibs_flip_pops.c -lm -lz -o bin/adlibs_flip_pops
@@ -13,3 +15,6 @@ bin/calc_fhat: src/calc_fhat.c
 
 bin/pi_pops: src/pi_pops.c
 	$(CC) src/pi_pops.c -lm -lz -o bin/pi_pops
+
+clean:
+	rm -vf $(EXECUTABLES)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC=gcc
+CC=gcc -std=c99
 
 all: bin/adlibs_flip_pops bin/adlibs_score bin/calc_fhat bin/pi_pops
 

--- a/bin/adlibs.py
+++ b/bin/adlibs.py
@@ -947,17 +947,27 @@ def main(args):
     # Define a numeric score to represent windows in which there was insufficient data
     # to calculate a score.
     skip_score = 999
-        
+
+    tasks = []
     pool = Pool(processes=options.num_procs)
     for hybrid_index in range(0, len(options.hybrid)):
         #worker(options, hybrid_index, pops_flipped, window, f, pi1, pi2, pi_between, resample_prob, resample_prob_x, skip_score, outprefix)
         proc = pool.apply_async(worker, [options, hybrid_index, pops_flipped, window, \
             f, pi1, pi2, pi_between, resample_prob, \
             resample_prob_x, skip_score, outprefix])
+        tasks.append(proc)
+
+    for idx, proc in enumerate(tasks):
+        if options.debug:
+            print("# Waiting for worker process %i of %i" % (idx, len(tasks)),
+                  file=sys.stderr)
+
+        # Re-throw exceptions from async processes
+        proc.get()
+
     pool.close()
     pool.join()
-    
-    
-if __name__ == "__main__" :
-    sys.exit(main(sys.argv))
 
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/bin/adlibs.py
+++ b/bin/adlibs.py
@@ -119,7 +119,7 @@ def parse_args():
         default=None)
     parser.add_argument("--gens", "-g", help=\
         "The estimated number of generations since admixture.",
-        required=False,
+        required=True,
         type=int)
     parser.add_argument("--pop_size", "-N", help=\
         "The estimated population size of the admixed population.",

--- a/src/adlibs_flip_pops.c
+++ b/src/adlibs_flip_pops.c
@@ -26,4 +26,6 @@ int main(int argc, char *argv[]) {
         }
         fprintf(stdout, "%s", line);
     }
+
+    return 0;
 }

--- a/src/adlibs_flip_pops.c
+++ b/src/adlibs_flip_pops.c
@@ -7,12 +7,12 @@ AA becomes BB and BB becomes AA.
 #include <stdlib.h>
 #include <string.h>
 
-int main(int argc, char *argv[]) {   
-    FILE *instream = stdin;
-    
+int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
+
     // Buffer to store lines
     char line[100];
-    
     while(fgets(line, sizeof(line), stdin)){
         // State name should be the last 2 letters on the line.
         int linelen = strlen(line);

--- a/src/adlibs_score.c
+++ b/src/adlibs_score.c
@@ -515,7 +515,7 @@ int main(int argc, char *argv[]) {
     
     //float score;
     
-    while(progress_h = kseq_read(hybrid) >= 0){
+    while((progress_h = kseq_read(hybrid)) >= 0){
         if (verbose_flag){
             fprintf(stderr, "Processing seq %s\n", hybrid->name.s);
         }

--- a/src/adlibs_score.c
+++ b/src/adlibs_score.c
@@ -30,7 +30,7 @@ kseq_t* parse_fasta(char *filename){
     }
 }
 
-inline const char capitalize(char base){
+const char capitalize(char base){
     if (base == 'a'){
         return 'A';
     } else if (base == 'c'){
@@ -53,13 +53,13 @@ struct flex_array {
     int *arr;
 };
 
-void inline init_array(struct flex_array *a){
+void init_array(struct flex_array *a){
     a->arr = (int *) malloc(11 * sizeof(int));
     a->index = 0;
     a->len = 10;
 }
 
-void inline add_item(struct flex_array *a, int item){
+void add_item(struct flex_array *a, int item){
     if (a->index == a->len){
         a->len *= 2;
         a->arr = (int *) realloc(a->arr, (a->len) * sizeof(int) + 1);
@@ -72,7 +72,7 @@ void inline add_item(struct flex_array *a, int item){
     a->index++;
 }
 
-void inline free_array(struct flex_array *a){
+void free_array(struct flex_array *a){
     // First zero it out to make sure it doesn't mess things up in the
     // future.
     free(a->arr);
@@ -92,7 +92,7 @@ float get_rand(){
 /**
  * Function to compute a score in a given window.
  */
-inline const float calc_score_window(kseq_t* pop1[], int num_pop1, \
+const float calc_score_window(kseq_t* pop1[], int num_pop1, \
     kseq_t* pop2[], int num_pop2, kseq_t* hybrid, long int win_start, long int win_end, \
     float skip, int skipscore, int mask_cpg){
     

--- a/src/adlibs_score.c
+++ b/src/adlibs_score.c
@@ -96,41 +96,33 @@ const float calc_score_window(kseq_t* pop1[], int num_pop1, \
     kseq_t* pop2[], int num_pop2, kseq_t* hybrid, long int win_start, long int win_end, \
     float skip, int skipscore, int mask_cpg){
     
-    long int baseIndex = win_start;
-    int pop1_index = 0;
-    int pop2_index = 0;
-        
     // These arrays will keep track of whether or not we are currently in 
     // an IBS tract with each individual from each ancestral population.
     // If so, they will store the index at which that match began.
     long int match_1[num_pop1];
-    for (pop1_index; pop1_index < num_pop1; pop1_index++){
+    for (int pop1_index = 0; pop1_index < num_pop1; pop1_index++){
         match_1[pop1_index] = -1;
     }
-    pop1_index = 0;
     long int match_2[num_pop2];
-    for (pop2_index; pop2_index < num_pop2; pop2_index++){
+    for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
         match_2[pop2_index] = -1;
     }
-    pop2_index = 0;
     
     // These arrays will store an array of each IBS tract length found with
     // each individual in both of the ancestral populations.
     struct flex_array *ibs_1 = malloc(num_pop1 * sizeof(struct flex_array));
-    for (pop1_index; pop1_index < num_pop1; pop1_index++){
+    for (int pop1_index = 0; pop1_index < num_pop1; pop1_index++){
         struct flex_array arr;
         init_array(&arr);
         memcpy(&ibs_1[pop1_index], &arr, sizeof(struct flex_array));
     }
-    pop1_index = 0;
     
     struct flex_array *ibs_2 = malloc(num_pop2 * sizeof(struct flex_array));
-    for (pop2_index; pop2_index < num_pop2; pop2_index++){
+    for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
         struct flex_array arr;
         init_array(&arr);
         memcpy(&ibs_2[pop2_index], &arr, sizeof(struct flex_array));
     }
-    pop2_index = 0;
     
     // Store the number of "N" bases found in query sequence
     int n_count_query = 0;
@@ -142,10 +134,7 @@ const float calc_score_window(kseq_t* pop1[], int num_pop1, \
     
     int added_count = 0;
     
-    for (baseIndex; baseIndex < win_end; baseIndex++){
-        
-        unsigned char pop1chr;
-        unsigned char pop2chr;
+    for (long int baseIndex = win_start; baseIndex < win_end; baseIndex++){
         unsigned char hchr = capitalize(hybrid->seq.s[baseIndex]);
         if (mask_cpg && ((hchr == 'G' && baseIndex > 0 && 
             capitalize(hybrid->seq.s[baseIndex-1]) == 'C') ||
@@ -157,8 +146,8 @@ const float calc_score_window(kseq_t* pop1[], int num_pop1, \
             n_count_query++;
         }
         
-        for (pop1_index; pop1_index < num_pop1; pop1_index++){
-            pop1chr = capitalize(pop1[pop1_index]->seq.s[baseIndex]);
+        for (int pop1_index = 0; pop1_index < num_pop1; pop1_index++){
+            unsigned char pop1chr = capitalize(pop1[pop1_index]->seq.s[baseIndex]);
             if (mask_cpg && ((pop1chr == 'G' && baseIndex > 0 && 
                 capitalize(pop1[pop1_index]->seq.s[baseIndex-1]) == 'C') ||
                 (pop1chr == 'C' && baseIndex < win_end-1 && 
@@ -181,8 +170,7 @@ const float calc_score_window(kseq_t* pop1[], int num_pop1, \
                 if (ibs_1[pop1_index].index > 0){
                     float prev_ibs_sum = 0;
                     float prev_ibs_tot = 0;
-                    int prev_ibs_index = 0;
-                    for (prev_ibs_index; prev_ibs_index < ibs_1[pop1_index].index; \
+                    for (int prev_ibs_index = 0; prev_ibs_index < ibs_1[pop1_index].index; \
                         prev_ibs_index++){
                         prev_ibs_sum += ibs_1[pop1_index].arr[prev_ibs_index];
                         prev_ibs_tot++;   
@@ -228,13 +216,12 @@ const float calc_score_window(kseq_t* pop1[], int num_pop1, \
                 match_1[pop1_index] = -1;
             }
         }
-        pop1_index = 0;
         
-        for (pop2_index; pop2_index < num_pop2; pop2_index++){
-            pop2chr = capitalize(pop2[pop2_index]->seq.s[baseIndex]);
-            if (mask_cpg && ((pop2chr == 'G' && baseIndex > 0 &&
+        for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
+            unsigned char pop2chr = capitalize(pop2[pop2_index]->seq.s[baseIndex]);
+            if (mask_cpg && ((pop2chr == 'G' && baseIndex > 0 && 
                 capitalize(pop2[pop2_index]->seq.s[baseIndex-1]) == 'C') ||
-                (pop2chr == 'C' && baseIndex < win_end-1 &&
+                (pop2chr == 'C' && baseIndex < win_end-1 && 
                 capitalize(pop2[pop2_index]->seq.s[baseIndex+1]) == 'G'))){
                 pop2chr = 'N';
             }
@@ -243,8 +230,7 @@ const float calc_score_window(kseq_t* pop1[], int num_pop1, \
                 if (ibs_2[pop2_index].index > 0){
                     float prev_ibs_sum = 0;
                     float prev_ibs_tot = 0;
-                    int prev_ibs_index = 0;
-                    for (prev_ibs_index; prev_ibs_index < ibs_2[pop2_index].index; \
+                    for (int prev_ibs_index = 0; prev_ibs_index < ibs_2[pop2_index].index; \
                         prev_ibs_index++){
                         prev_ibs_sum += ibs_2[pop2_index].arr[prev_ibs_index];
                         prev_ibs_tot ++;   
@@ -290,7 +276,6 @@ const float calc_score_window(kseq_t* pop1[], int num_pop1, \
             }
   
         }
-        pop2_index = 0;
     }
     
     
@@ -298,20 +283,18 @@ const float calc_score_window(kseq_t* pop1[], int num_pop1, \
     // end, was found. Doing this will probably bias things downward (since these are
     // incomplete IBS tracts).
     /**
-    for (pop1_index; pop1_index < num_pop1; pop1_index++){
+    for (int pop1_index = 0; pop1_index < num_pop1; pop1_index++){
         //if (match_1[pop1_index] > -1){
         if (match_1[pop1_index] > -1 && ibs_1[pop1_index].index == 0){
             add_item(&ibs_1[pop1_index], win_end-match_1[pop1_index]);
         }
     }
-    pop1_index = 0;
-    for (pop2_index; pop2_index < num_pop2; pop2_index++){
+    for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
         //if (match_2[pop2_index] > -1){
         if (match_2[pop2_index] > -1 && ibs_2[pop2_index].index == 0){
             add_item(&ibs_2[pop2_index], win_end-match_2[pop2_index]);
         }
     }
-    pop2_index = 0;
     **/
     
     // Calculate score.
@@ -322,14 +305,12 @@ const float calc_score_window(kseq_t* pop1[], int num_pop1, \
         (float)n_count_1/winsize/(float)num_pop1 >= skip || 
         (float)n_count_2/winsize/(float)num_pop2 >= skip){
         // Free everything.
-        for (pop1_index; pop1_index < num_pop1; pop1_index++){
+        for (int pop1_index = 0; pop1_index < num_pop1; pop1_index++){
             free_array(&ibs_1[pop1_index]);
         }
-        pop1_index = 0;
-        for (pop2_index; pop2_index < num_pop2; pop2_index++){
+        for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
             free_array(&ibs_2[pop2_index]);
         }
-        pop2_index = 0;
         return skipscore;
     }
     
@@ -340,11 +321,9 @@ const float calc_score_window(kseq_t* pop1[], int num_pop1, \
     float ibs_sum_2 = 0;
     float ibs_tot_2 = 0;
     
-    pop1_index = 0; 
-    for (pop1_index; pop1_index < num_pop1; pop1_index++){
+    for (int pop1_index = 0; pop1_index < num_pop1; pop1_index++){
         int pop_total = (int) ibs_1[pop1_index].index;
-        int ibs_index = 0;
-        for (ibs_index; ibs_index < pop_total; ibs_index++){
+        for (int ibs_index = 0; ibs_index < pop_total; ibs_index++){
             ibs_sum_1 += (float) ibs_1[pop1_index].arr[ibs_index];
             ibs_tot_1++;
         }
@@ -354,10 +333,8 @@ const float calc_score_window(kseq_t* pop1[], int num_pop1, \
         ibs_tot_1 = 1;
     }
     
-    pop2_index = 0;
-    for (pop2_index; pop2_index < num_pop2; pop2_index++){
-        int ibs_index = 0;
-        for (ibs_index; ibs_index < ibs_2[pop2_index].index; ibs_index++){
+    for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
+        for (int ibs_index = 0; ibs_index < ibs_2[pop2_index].index; ibs_index++){
             ibs_sum_2 += (float) ibs_2[pop2_index].arr[ibs_index];
             ibs_tot_2++;
         }
@@ -369,14 +346,12 @@ const float calc_score_window(kseq_t* pop1[], int num_pop1, \
     float ibs_avg_1 = ibs_sum_1/ibs_tot_1;
     float ibs_avg_2 = ibs_sum_2/ibs_tot_2;
     // Free everything.
-    for (pop1_index; pop1_index < num_pop1; pop1_index++){
+    for (int pop1_index = 0; pop1_index < num_pop1; pop1_index++){
         free_array(&ibs_1[pop1_index]);
     }
-    pop1_index = 0;
-    for (pop2_index; pop2_index < num_pop2; pop2_index++){
+    for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
         free_array(&ibs_2[pop2_index]);
     }
-    pop2_index = 0;
     if (ibs_avg_1 == 0 || ibs_avg_2 == 0){
         return skipscore;
     }
@@ -506,22 +481,16 @@ int main(int argc, char *argv[]) {
     int progress_h;
     int progress_1[num_pop1];
     int progress_2[num_pop2];
-    
-    int pop1_index = 0;
-    int pop2_index = 0;
-    
-    long int win_start = 0;
-    long int win_end = 0;
-    
+
     //float score;
-    
+
     while((progress_h = kseq_read(hybrid)) >= 0){
         if (verbose_flag){
             fprintf(stderr, "Processing seq %s\n", hybrid->name.s);
         }
         
         // Advance all files by one sequence.
-        for (pop1_index; pop1_index < num_pop1; pop1_index++){
+        for (int pop1_index = 0; pop1_index < num_pop1; pop1_index++){
             progress_1[pop1_index] = kseq_read(pop1[pop1_index]);
             if (strcmp(pop1[pop1_index]->name.s, hybrid->name.s) != 0){
                 fprintf(stderr, "ERROR: sequence IDs %s and %s do not match. \
@@ -530,8 +499,7 @@ pop1[pop1_index]->name.s, hybrid->name.s);
                 exit(1);
             }
         }
-        pop1_index = 0;
-        for (pop2_index; pop2_index < num_pop2; pop2_index++){
+        for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
             progress_2[pop2_index] = kseq_read(pop2[pop2_index]);
             if (strcmp(pop2[pop2_index]->name.s, hybrid->name.s) != 0){
                 fprintf(stderr, "ERROR: sequence IDs %s and %s do not match. \
@@ -540,24 +508,20 @@ pop2[pop2_index]->name.s, hybrid->name.s);
                 exit(1);
             }
         }
-        pop2_index = 0;
 
         // Process this sequence.
-        
         // First, determine shortest sequence.
         long int shortest = pop1[num_pop1-1]->seq.l;
-        for (pop1_index; pop1_index < num_pop1-1; pop1_index++){
+        for (int pop1_index = 0; pop1_index < num_pop1-1; pop1_index++){
             if (pop1[pop1_index]->seq.l < shortest){
                 shortest = pop1[pop1_index]->seq.l;
             }
         }
-        pop1_index = 0;
-        for (pop2_index; pop2_index < num_pop2; pop2_index++){
+        for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
             if (pop2[pop2_index]->seq.l < shortest){
                 shortest = pop2[pop2_index]->seq.l;
             }
         }
-        pop2_index = 0;
         
         // Skip this sequence if ANY individual is missing it.
         if (shortest < window){
@@ -565,8 +529,8 @@ pop2[pop2_index]->name.s, hybrid->name.s);
         }
         else{
             // Calculate score in every window.
-            for (win_start; win_start < shortest; win_start = win_start + window){
-                win_end = win_start + window;
+            for (long int win_start = 0; win_start < shortest; win_start = win_start + window){
+                long int win_end = win_start + window;
                 if (win_end >= shortest){
                     win_end = shortest-1;
                 }
@@ -583,8 +547,6 @@ pop2[pop2_index]->name.s, hybrid->name.s);
                         win_end, score);
                 }
             }
-            win_start = 0;
-            win_end = 0;
         }
         
     }
@@ -592,10 +554,10 @@ pop2[pop2_index]->name.s, hybrid->name.s);
     // Clean up.
     kseq_destroy(hybrid);
     
-    for (pop1_index; pop1_index < num_pop1; pop1_index++){
+    for (int pop1_index = 0; pop1_index < num_pop1; pop1_index++){
         kseq_destroy(pop1[pop1_index]);
     }
-    for (pop2_index; pop2_index < num_pop2; pop2_index++){
+    for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
         kseq_destroy(pop2[pop2_index]);
     }
     

--- a/src/adlibs_score.c
+++ b/src/adlibs_score.c
@@ -232,11 +232,11 @@ const float calc_score_window(kseq_t* pop1[], int num_pop1, \
         
         for (pop2_index; pop2_index < num_pop2; pop2_index++){
             pop2chr = capitalize(pop2[pop2_index]->seq.s[baseIndex]);
-            if (mask_cpg && ((pop1chr == 'G' && baseIndex > 0 && 
-                capitalize(pop1[pop1_index]->seq.s[baseIndex-1]) == 'C') ||
-                (pop1chr == 'C' && baseIndex < win_end-1 && 
-                capitalize(pop1[pop1_index]->seq.s[baseIndex+1]) == 'G'))){
-                pop1chr = 'N';
+            if (mask_cpg && ((pop2chr == 'G' && baseIndex > 0 &&
+                capitalize(pop2[pop2_index]->seq.s[baseIndex-1]) == 'C') ||
+                (pop2chr == 'C' && baseIndex < win_end-1 &&
+                capitalize(pop2[pop2_index]->seq.s[baseIndex+1]) == 'G'))){
+                pop2chr = 'N';
             }
             if (pop2chr == 'N' || hchr == 'N'){
                 // (see above)

--- a/src/calc_fhat.c
+++ b/src/calc_fhat.c
@@ -225,7 +225,7 @@ void main(int argc, char *argv[]) {
     int progress_hybrid = 0;
     int progress_out = 0;
     
-    while(progress_1a = kseq_read(pop1a) >= 0){
+    while((progress_1a = kseq_read(pop1a)) >= 0){
         if (verbose_flag){
             fprintf(stderr, "Processing seq %s\n", pop1a->name.s);
         }

--- a/src/calc_fhat.c
+++ b/src/calc_fhat.c
@@ -38,15 +38,15 @@ struct fhat_stats {
  * Function to compute f_hat statistics (numbers of different types of sites)
  * on a given scaffold.
  */
-const struct fhat_stats fhat_seq(char* anc2, char* hybrid, char* anc1a, char* anc1b, 
-    char* out, long int shortest){
+struct fhat_stats fhat_seq(char* anc2, char* hybrid, char* anc1a, char* anc1b, 
+    char* out, size_t shortest){
     struct fhat_stats stats;
     stats.abxba = 0;
     stats.baxba = 0;
     stats.axbba = 0;
     stats.bxaba = 0;
     
-    for (int baseIndex = 0; baseIndex < shortest; baseIndex++){
+    for (size_t baseIndex = 0; baseIndex < shortest; baseIndex++){
         if (anc2[baseIndex] != 'N' && hybrid[baseIndex] != 'N' &&
             anc1a[baseIndex] != 'N' && anc1b[baseIndex] != 'N' &&
             out[baseIndex] != 'N'){
@@ -248,7 +248,7 @@ int main(int argc, char *argv[]) {
         }
         
         // Determine shortest sequence.
-        long int shortest = pop1a->seq.l;
+        size_t shortest = pop1a->seq.l;
         if (pop1b->seq.l < shortest){
             shortest = pop1b->seq.l;
         }

--- a/src/calc_fhat.c
+++ b/src/calc_fhat.c
@@ -38,7 +38,7 @@ struct fhat_stats {
  * Function to compute f_hat statistics (numbers of different types of sites)
  * on a given scaffold.
  */
-inline const struct fhat_stats fhat_seq(char* anc2, char* hybrid, char* anc1a, char* anc1b, 
+const struct fhat_stats fhat_seq(char* anc2, char* hybrid, char* anc1a, char* anc1b, 
     char* out, long int shortest){
     struct fhat_stats stats;
     stats.abxba = 0;

--- a/src/calc_fhat.c
+++ b/src/calc_fhat.c
@@ -46,8 +46,7 @@ const struct fhat_stats fhat_seq(char* anc2, char* hybrid, char* anc1a, char* an
     stats.axbba = 0;
     stats.bxaba = 0;
     
-    int baseIndex = 0;
-    for (baseIndex; baseIndex < shortest; baseIndex++){
+    for (int baseIndex = 0; baseIndex < shortest; baseIndex++){
         if (anc2[baseIndex] != 'N' && hybrid[baseIndex] != 'N' &&
             anc1a[baseIndex] != 'N' && anc1b[baseIndex] != 'N' &&
             out[baseIndex] != 'N'){
@@ -123,7 +122,7 @@ using the bases already read.\n");
    exit(code); 
 }
 
-void main(int argc, char *argv[]) {    
+int main(int argc, char *argv[]) {
     // Define arguments 
     static struct option long_options[] = {
         {"pop1a", required_argument, 0, 'a'},
@@ -220,21 +219,16 @@ void main(int argc, char *argv[]) {
     // Iterate through every sequence in the FASTA file; for each,
     // compute relevant statistics for that sequence.
     int progress_1a = 0;
-    int progress_1b = 0;
-    int progress_2 = 0;
-    int progress_hybrid = 0;
-    int progress_out = 0;
-    
     while((progress_1a = kseq_read(pop1a)) >= 0){
         if (verbose_flag){
             fprintf(stderr, "Processing seq %s\n", pop1a->name.s);
         }
 
         // Advance all files by one sequence.
-        progress_1b = kseq_read(pop1b);
-        progress_2 = kseq_read(pop2);
-        progress_hybrid = kseq_read(hybrid);
-        progress_out = kseq_read(outgroup);
+        int progress_1b = kseq_read(pop1b);
+        int progress_2 = kseq_read(pop2);
+        int progress_hybrid = kseq_read(hybrid);
+        int progress_out = kseq_read(outgroup);
         
         // Process this sequence.
         
@@ -312,5 +306,7 @@ void main(int argc, char *argv[]) {
     kseq_destroy(pop2);
     kseq_destroy(hybrid);
     kseq_destroy(outgroup);
+
+    return 0;
 }
 

--- a/src/pi_pops.c
+++ b/src/pi_pops.c
@@ -38,7 +38,7 @@ struct pi_stats {
     long int seqlen_between;
 };
 
-inline const char capitalize(char base){
+const char capitalize(char base){
     if (base == 'a'){
         return 'A';
     } else if (base == 'c'){
@@ -56,7 +56,7 @@ inline const char capitalize(char base){
 /**
  * Function to compute numbers needed for computation of pi, on a single scaffold.
  */
-inline const struct pi_stats pi_seq(kseq_t* pop1[], kseq_t* pop2[], int num_pop1, 
+const struct pi_stats pi_seq(kseq_t* pop1[], kseq_t* pop2[], int num_pop1, 
     int num_pop2, long int shortest){
     struct pi_stats stats;
     stats.diffs_pop1 = 0;
@@ -170,7 +170,7 @@ inline const struct pi_stats pi_seq(kseq_t* pop1[], kseq_t* pop2[], int num_pop1
     return stats;
 }
 
-inline const int binomial_coeff(int n, int k){
+const int binomial_coeff(int n, int k){
     int numerator = 1;
     int denominator = 1;
     

--- a/src/pi_pops.c
+++ b/src/pi_pops.c
@@ -66,8 +66,7 @@ const struct pi_stats pi_seq(kseq_t* pop1[], kseq_t* pop2[], int num_pop1,
     stats.seqlen_pop2 = shortest;
     stats.seqlen_between = shortest;
     
-    int baseIndex = 0;
-    for (baseIndex; baseIndex < shortest; baseIndex++){
+    for (int baseIndex = 0; baseIndex < shortest; baseIndex++){
         
         long int this_pop1_diffs = 0;
         long int this_pop2_diffs = 0;
@@ -76,26 +75,15 @@ const struct pi_stats pi_seq(kseq_t* pop1[], kseq_t* pop2[], int num_pop1,
         int pop1_n = 0;
         int pop2_n = 0;
         
-        int pop2_index = 0;
-        int pop1_index2 = 0;
-        int pop1_index = 0;
-        int pop2_index2 = 0;
-        
-        char pop1chr;
-        char pop1bchr;
-        char pop2chr;
-        char pop2bchr;
-        
-        for (pop1_index; pop1_index < num_pop1; pop1_index++){
-            pop1chr = capitalize(pop1[pop1_index]->seq.s[baseIndex]);
+        for (int pop1_index = 0; pop1_index < num_pop1; pop1_index++){
+            char pop1chr = capitalize(pop1[pop1_index]->seq.s[baseIndex]);
             if (pop1chr == 'N'){
                 pop1_n = 1;
                 break;
             }
             if (pop1_index > 0 && pop1_n == 0){
-                pop1_index2 = 0;
-                for (pop1_index2; pop1_index2 < pop1_index; pop1_index2++){
-                    pop1bchr = capitalize(pop1[pop1_index2]->seq.s[baseIndex]);
+                for (int pop1_index2 = 0; pop1_index2 < pop1_index; pop1_index2++){
+                    char pop1bchr = capitalize(pop1[pop1_index2]->seq.s[baseIndex]);
                     // We already checked this base as pop1chr, so we don't
                     // need to check to see if it's N.
                     if (pop1chr != pop1bchr){
@@ -103,9 +91,8 @@ const struct pi_stats pi_seq(kseq_t* pop1[], kseq_t* pop2[], int num_pop1,
                     }
                 }
             }
-            pop2_index = 0;
-            for (pop2_index; pop2_index < num_pop2; pop2_index++){
-                pop2chr = capitalize(pop2[pop2_index]->seq.s[baseIndex]);
+            for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
+                char pop2chr = capitalize(pop2[pop2_index]->seq.s[baseIndex]);
                 if (pop2chr == 'N'){
                     pop2_n = 1;
                     break;
@@ -116,17 +103,15 @@ const struct pi_stats pi_seq(kseq_t* pop1[], kseq_t* pop2[], int num_pop1,
             }
         }
         
-        pop2_index = 0;
-        for (pop2_index; pop2_index < num_pop2; pop2_index++){
-            pop2chr = capitalize(pop2[pop2_index]->seq.s[baseIndex]);
+        for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
+            char pop2chr = capitalize(pop2[pop2_index]->seq.s[baseIndex]);
             if (pop2chr == 'N' || pop2_n == 1){
                 pop2_n = 1;
                 break;
             }
             if (pop2_index > 0 && pop2_n == 0){
-                pop2_index2 = 0;
-                for (pop2_index2; pop2_index2 < pop2_index; pop2_index2++){
-                    pop2bchr = capitalize(pop2[pop2_index2]->seq.s[baseIndex]);
+                for (int pop2_index2 = 0; pop2_index2 < pop2_index; pop2_index2++){
+                    char pop2bchr = capitalize(pop2[pop2_index2]->seq.s[baseIndex]);
                     // We already checked this base as pop2chr, so we don't
                     // need to check to see if it's N.
                     if (pop2chr != pop2bchr){
@@ -174,12 +159,10 @@ const int binomial_coeff(int n, int k){
     int numerator = 1;
     int denominator = 1;
     
-    int term = n;
-    for (term; term >= n-(k-1); term--){
+    for (int term = n; term >= n-(k-1); term--){
         numerator = numerator*term;
     }
-    term = k;
-    for (term; term >= 1; term--){
+    for (int term = k; term >= 1; term--){
         denominator = denominator*term;
     }
     return numerator/denominator;
@@ -210,7 +193,7 @@ using the bases already read.\n");
    exit(code); 
 }
 
-void main(int argc, char *argv[]) {    
+int main(int argc, char *argv[]) {
     
     // Set default argument values
     int num_pop1 = 0;
@@ -287,46 +270,37 @@ population.\n");
     int progress_1[num_pop1];
     int progress_2[num_pop2];
     
-    int pop1_index = 0;
-    int pop2_index = 0;
-    
-    for (pop1_index; pop1_index < num_pop1; pop1_index++){
+    for (int pop1_index = 0; pop1_index < num_pop1; pop1_index++){
         progress_1[pop1_index] = 0;
     }
-    pop1_index = 0;
     
-    for (pop2_index; pop2_index < num_pop2; pop2_index++){
+    for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
         progress_2[pop2_index] = 0;
     }
-    pop2_index = 0;
     
     while((progress_1[0] = kseq_read(pop1[0])) >= 0){
         if (verbose_flag){
             fprintf(stderr, "Processing seq %s\n", pop1[0]->name.s);
         }
-        pop1_index++;
         
         // Advance all files by one sequence.
-        for (pop1_index; pop1_index < num_pop1; pop1_index++){
+        for (int pop1_index = 1; pop1_index < num_pop1; pop1_index++){
             progress_1[pop1_index] = kseq_read(pop1[pop1_index]);
         }
-        pop1_index = 0;
-        for (pop2_index; pop2_index < num_pop2; pop2_index++){
+        for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
             progress_2[pop2_index] = kseq_read(pop2[pop2_index]);
         }
-        pop2_index = 0;
 
         // Process this sequence.
         
         // First, determine shortest sequence.
         long int shortest = pop1[num_pop1-1]->seq.l;
-        for (pop1_index; pop1_index < num_pop1-1; pop1_index++){
+        for (int pop1_index = 0; pop1_index < num_pop1-1; pop1_index++){
             if (pop1[pop1_index]->seq.l < shortest){
                 shortest = pop1[pop1_index]->seq.l;
             }
         }
-        pop1_index = 0;
-        for (pop2_index; pop2_index < num_pop2; pop2_index++){
+        for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
             if (pop2[pop2_index]->seq.l < shortest){
                 shortest = pop2[pop2_index]->seq.l;
             }
@@ -346,18 +320,16 @@ population.\n");
         seqlen_between += stats.seqlen_between;
         
         // If any sequence has reached the end of the file, bail out here.
-        for (pop1_index; pop1_index < num_pop1; pop1_index++){
+        for (int pop1_index = 0; pop1_index < num_pop1; pop1_index++){
             if (progress_1[pop1_index] < 0){
                 break;
             }
         }
-        pop1_index = 0;
-        for (pop2_index; pop2_index < num_pop2; pop2_index++){
+        for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
             if (progress_2[pop2_index] < 0){
                 break;
             }
         }
-        pop2_index = 0;
         
         // If we are set to stop scanning after a given number of bases,
         // bail out here.
@@ -380,12 +352,13 @@ population.\n");
     printf("%f\t%f\t%f\n", pi1, pi2, pibetween);
     
     // Clean up.
-    for (pop1_index; pop1_index < num_pop1; pop1_index++){
+    for (int pop1_index = 0; pop1_index < num_pop1; pop1_index++){
         kseq_destroy(pop1[pop1_index]);
     }
-    for (pop2_index; pop2_index < num_pop2; pop2_index++){
+    for (int pop2_index = 0; pop2_index < num_pop2; pop2_index++){
         kseq_destroy(pop2[pop2_index]);
     }
 
+    return 0;
 }
 

--- a/src/pi_pops.c
+++ b/src/pi_pops.c
@@ -300,7 +300,7 @@ population.\n");
     }
     pop2_index = 0;
     
-    while(progress_1[0] = kseq_read(pop1[0]) >= 0){
+    while((progress_1[0] = kseq_read(pop1[0])) >= 0){
         if (verbose_flag){
             fprintf(stderr, "Processing seq %s\n", pop1[0]->name.s);
         }

--- a/src/pi_pops.c
+++ b/src/pi_pops.c
@@ -38,7 +38,7 @@ struct pi_stats {
     long int seqlen_between;
 };
 
-const char capitalize(char base){
+char capitalize(char base){
     if (base == 'a'){
         return 'A';
     } else if (base == 'c'){
@@ -56,8 +56,8 @@ const char capitalize(char base){
 /**
  * Function to compute numbers needed for computation of pi, on a single scaffold.
  */
-const struct pi_stats pi_seq(kseq_t* pop1[], kseq_t* pop2[], int num_pop1, 
-    int num_pop2, long int shortest){
+struct pi_stats pi_seq(kseq_t* pop1[], kseq_t* pop2[], int num_pop1,
+    int num_pop2, size_t shortest){
     struct pi_stats stats;
     stats.diffs_pop1 = 0;
     stats.diffs_pop2 = 0;
@@ -66,8 +66,7 @@ const struct pi_stats pi_seq(kseq_t* pop1[], kseq_t* pop2[], int num_pop1,
     stats.seqlen_pop2 = shortest;
     stats.seqlen_between = shortest;
     
-    for (int baseIndex = 0; baseIndex < shortest; baseIndex++){
-        
+    for (size_t baseIndex = 0; baseIndex < shortest; baseIndex++){
         long int this_pop1_diffs = 0;
         long int this_pop2_diffs = 0;
         long int this_between_diffs = 0;
@@ -155,7 +154,7 @@ const struct pi_stats pi_seq(kseq_t* pop1[], kseq_t* pop2[], int num_pop1,
     return stats;
 }
 
-const int binomial_coeff(int n, int k){
+int binomial_coeff(int n, int k){
     int numerator = 1;
     int denominator = 1;
     
@@ -202,7 +201,6 @@ int main(int argc, char *argv[]) {
     kseq_t* pop2[10];
     long int base_limit = -1;
     
-    int option_index = 0;
     int ch;
     
     // Pointer to end character of strings when converting to floats(?)
@@ -294,7 +292,7 @@ population.\n");
         // Process this sequence.
         
         // First, determine shortest sequence.
-        long int shortest = pop1[num_pop1-1]->seq.l;
+        size_t shortest = pop1[num_pop1-1]->seq.l;
         for (int pop1_index = 0; pop1_index < num_pop1-1; pop1_index++){
             if (pop1[pop1_index]->seq.l < shortest){
                 shortest = pop1[pop1_index]->seq.l;

--- a/src/pi_pops.c
+++ b/src/pi_pops.c
@@ -347,13 +347,13 @@ population.\n");
         
         // If any sequence has reached the end of the file, bail out here.
         for (pop1_index; pop1_index < num_pop1; pop1_index++){
-            if (pop1[pop1_index] < 0){
+            if (progress_1[pop1_index] < 0){
                 break;
             }
         }
         pop1_index = 0;
         for (pop2_index; pop2_index < num_pop2; pop2_index++){
-            if (pop2[pop2_index] < 0){
+            if (progress_2[pop2_index] < 0){
                 break;
             }
         }


### PR DESCRIPTION
This patch-set includes a number of bug-fixes and code-quality improvements for ad-libs:

 * Compilation with CLANG and some versions of GCC is fixed; the use of inline cause missing symbol errors during compilation, which is resolved simply by removing these. 
 * The EOF checks in pi_pops.c mistakenly compare against pop1 and pops2, instead of progress_1 and progress_2. pops1 and pops2 are arrays of pointers, and the < 0 comparison can therefore never be true. This was fixed by using progress_[12] instead of pops[12] in the checks.
 * Several while loops lack parenthesis around assignments, resulting in the comparison being saved. Currently this does not cause problems, but future changes may expose this problem, so the missing parentheses were added.
 * The cpg check for pop2 mistakenly used the loop variables from pop1. This was corrected.
 * The C standard was set to C99, and loop variables declarations were moved possible, in order to reduce their scopes. This should help avoid bugs like the cpg check bug.
 * The --gens parameter was not marked as required, but is used in all runs. It is now marked as required.
 * The get method is now called on the async objects produced by the multiprocessing pool in adlibs.py. This is the minimum required to ensure that unhandled exception raised in a worker processes are not simply swallowed.
 * Various warnings were enabled, the resulting issues were fixed, and a 'make clean' target was added.
 * A gitignore file was added to ignore the executables and python byte-code files.

There are other issues, such as missing checks on the returncode of subprocess.Popen calls, which I may submit additional patches for.